### PR TITLE
message counter was being incremented twice for unhandled midi events

### DIFF
--- a/midi.c
+++ b/midi.c
@@ -144,8 +144,8 @@ static midi_event_callback_t g_callbacks[EVT_MAX] = {0};
 
 // The null event callback is used by default for all events.
 static void null_event_cb(char channel, char a, char b) {
-    // Just implement the event counter.
-    ++g_message_counter;
+  // Do nothing. The invoke_callback() function will properly implement the
+  // global message counter.
 }
 
 


### PR DESCRIPTION
Fix for problem reported by user tyszja:

For MIDI messages that were not handled, the global message counter was being incremented twice, first in the invoke_callback() function, and then in the null_event_cb() function.

Quick solution was to remove the increment in null_event_cb() reducing it to an empty function call.
